### PR TITLE
Matches class namespace for ps-4 compliance

### DIFF
--- a/src/assetbundles/vzaddress/VzAddressAsset.php
+++ b/src/assetbundles/vzaddress/VzAddressAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2018 Superbig
  */
 
-namespace superbig\vzaddress\assetbundles\VzAddress;
+namespace superbig\vzaddress\assetbundles\vzaddress;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
When installing via composer, would get error 

```
Class superbig\vzaddress\assetbundles\VzAddress\VzAddressAsset located in ./vendor/superbig/craft-vzaddress/src/assetbundles/vzaddress/VzAddressAsset.php does not comply with psr-4 autoloading standard. Skipping.
```

This fixes and also matches it to the casing used in the [VzAddressFieldFieldAsset class](https://github.com/superbigco/craft-vzaddress/blob/master/src/assetbundles/vzaddressfieldfield/VzAddressFieldFieldAsset.php#L11)